### PR TITLE
Fix constant in adapter to match with DELETE events

### DIFF
--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -299,7 +299,7 @@ class _BaseTree(object):
 
                         self._i.add_watch(full_path, self._mask)
 
-                    if header.mask & inotify.constants.IN_MOVED_FROM:
+                    if header.mask & inotify.constants.IN_DELETE:
                         _LOGGER.debug("A directory has been removed. We're "
                                       "being recursive, but it would have "
                                       "automatically been deregistered: [%s]",


### PR DESCRIPTION
The previous behavior was duplicating a block of code and making
one of the two useless. This fixes that by replacing the constant to
IN_DELETE instead of IN_MOVED_FROM in one of the two blocks.

Signed-off-by: Raphaël Beamonte <raphael.beamonte@gmail.com>