### PR TITLE
Stay Python 2.6 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
   - "3.5"
 
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install pycparser==2.18; pip install unittest2; fi
   - pip install -r requirements.txt
   - pip install coveralls
 script: nosetests -s -v --with-coverage --cover-package=inotify

--- a/inotify/adapters.py
+++ b/inotify/adapters.py
@@ -166,7 +166,7 @@ class Inotify(object):
 
             header = _INOTIFY_EVENT(*header_raw)
             type_names = self._get_event_names(header.mask)
-            _LOGGER.debug("Events received in stream: {}".format(type_names))
+            _LOGGER.debug("Events received in stream: {0}".format(type_names))
 
             event_length = (_STRUCT_HEADER_LENGTH + header.len)
             if length < event_length:
@@ -225,7 +225,7 @@ class Inotify(object):
                 # (fd) looks to always match the inotify FD.
 
                 names = self._get_event_names(event_type)
-                _LOGGER.debug("Events received from epoll: {}".format(names))
+                _LOGGER.debug("Events received from epoll: {0}".format(names))
 
                 for (header, type_names, path, filename) \
                         in self._handle_inotify_event(fd):

--- a/tests/test_inotify.py
+++ b/tests/test_inotify.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import os
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 import inotify.constants
 import inotify.adapters


### PR DESCRIPTION
As there are many installations with only default 2.6 Python in place an no "supported" updates are available in official repos for OS we should try to stay Python 2.6 compatible... (At least all the Redhat/Centos 6 systems are affected)

* Update .travis.yml
** include v2.6 and for that version do the following addtional tasks:
*** explicitly install pycparser version 2.18 needed by coverall as this is latest version that's 2.6 compatible
*** install unittest2 to have the newer unittest features available for 2.6 so only minimal change required for test_inotify.py
* Update test_inotify.py
** import unittest2 as unittest for python version 2.6
* Update adapters.py
** change debug code to format syntax understood by 2.6