### PR TITLE
Utilize travis-ci pip cache for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-
+matrix:
+    include:
+        - os: linux
+          python: 2.6
+          cache: pip
+        - os: linux
+          python: 2.7
+        - os: linux
+          python: 3.3
+        - os: linux
+          python: 3.4
+        - os: linux
+          python: 3.5
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install pycparser==2.18; pip install unittest2; fi
   - pip install -r requirements.txt


### PR DESCRIPTION
To speed up the Python 2.6 test enable travis-ci pip cache for Python 2.6.
Enable only for 2.6 because cache handling takes quite much time (but less time than installing the non-prebuilt dependencies on 2.6...)